### PR TITLE
add link in guides readme to Google Cloud Platform Confidential Compute

### DIFF
--- a/api/v2/guides/README.md
+++ b/api/v2/guides/README.md
@@ -25,3 +25,4 @@ The following guides provide integration instructions based on the needs and req
 | :--- | :--- |
 | [Operator - Microsoft Azure](./operator-guide-azure-enclave.md) | IMPORTANT: This documentation is currently only a proof of concept. Please [contact](../../README.md#contact-info) the UID2 administrator for additional guidance.<br/><br/>Instructions for setting up Closed Operator service for running on Microsoft Azure Confidential Computing platform.  |
 | [Operator - AWS Marketplace](./operator-guide-aws-marketplace.md) | Instructions for setting up Closed Operator service for AWS Marketplace. |
+| [Operator - Google Cloud Platform Confidential Compute package](./operator-guide-gcp-enclave.md) | Instructions for setting up the Google Cloud Platform Confidential Compute package. |


### PR DESCRIPTION
Adding link to Guides summary table for Google Cloud Platform Confidential Compute doc.