### PR TITLE
correction to initial readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ UID2 is a deterministic ID that is based on personally identifiable information 
 | ID Type | Shared in Bid Stream? | Description |
 | :--- | :--- | :--- |
 | **Raw UID2** | No | An unencrypted alphanumeric identifier created through the UID2 APIs or SDKs with the user's verifiable personal data, such as a hashed or unhashed email address or a phone number, as input.<br/>To prevent re-identification of the original personal data, the input value is hashed and salted to create the raw UID2. The process that creates the raw UID2 is designed to create a secure, opaque value that can be stored by advertisers, third-party data providers, and demand-side platforms (DSPs). |
-| **UID2 Token (Advertising Token)** | Yes | An encrypted form of a raw UID2. The raw UID2 is further salted, hashed, and encrypted to produce a UID2 token, to ensure protection in the bid stream.<br/>UID2 tokens are designed to be used by publishers or publisher service providers. Supply-side platforms (SSPs) pass UID2 tokens in the bid stream and DSPs decrypt them at bid request time. |
+| **UID2 Token (Advertising Token)** | Yes | An encrypted form of a raw UID2. UID2 tokens are generated from hashed or unhashed email addresses or phone numbers that are converted to raw UID2s and then encrypted to ensure protection in the bid stream.<br/>UID2 tokens are designed to be used by publishers or publisher service providers. Supply-side platforms (SSPs) pass UID2 tokens in the bid stream and DSPs decrypt them at bid request time. |
 
 
 ### Components


### PR DESCRIPTION
Restore copy from 1/11/23 version for advertising token definition, to correct error.