### PR TITLE
fix broken links in JP files

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -111,7 +111,7 @@ UID2 は透明で相互運用可能なアプローチにより、広告エコシ
 
 次の図は、4 つのワークフローをすべてまとめたものです。各ワークフローについて、[参加者](#participants)、[コンポーネント](#components)、[UID2 識別子タイプ](#uid2-identifier-types)、および番号付きステップが色分けされています。
 
-![The UID2 Ecosystem](/images/UID2-workflows-ja.jpg)
+![The UID2 Ecosystem](images/UID2-workflows-ja.jpg)
 
 ## FAQs
 

--- a/api-ja/v1/README.md
+++ b/api-ja/v1/README.md
@@ -1,6 +1,6 @@
 # UID2 API v1 (Deprecated)
 
-> IMPORTANT: UID2 API v1 は非推奨となり、2023 年 3 月 31 日までにすべての v1 SDK ファイルとエンドポイント、v0 SDK ファイル、およびバージョン管理されていないエンドポイントが削除され、現在のユーザーのみがサポートされるようになります。2023 年 3 月 31 日までに、必ず [UID2 API v2 へのアップグレード](../../v2/upgrades/upgrade-guide.md) をお願いします。初めてフレームワークに触れる方は、[UID2 API v2](../v2/summary-doc-v2.md) をご利用ください。
+> IMPORTANT: UID2 API v1 は非推奨となり、2023 年 3 月 31 日までにすべての v1 SDK ファイルとエンドポイント、v0 SDK ファイル、およびバージョン管理されていないエンドポイントが削除され、現在のユーザーのみがサポートされるようになります。2023 年 3 月 31 日までに、必ず [UID2 API v2 へのアップグレード](../v2/upgrades/upgrade-guide.md) をお願いします。初めてフレームワークに触れる方は、[UID2 API v2](../v2/summary-doc-v2.md) をご利用ください。
 
 UID2 の定義、形式、指針、構成要素、その他の概念的な詳細については、 [UID2 概要](../../README-ja.md) を参照してください。連絡先やライセンス情報、正規化やハッシュエンコーディングの規則については、[Unified ID 2.0 API Documentation](../getting-started.md) を参照してください。API v2 の詳細については、[UID2 API v2 Documentation](../v2/summary-doc-v2.md) を参照してください。
 


### PR DESCRIPTION
After taking down v1 files in English, link check in Docusaurus showed 2 broken links. They might work in Git but the Japanese files will be going to Docusaurus soon anyway. Fixed them so all links are good.