### PR TITLE
fix: :bug: firefox desktop hero bg alignment

### DIFF
--- a/src/components/HomepageHero/styles.module.scss
+++ b/src/components/HomepageHero/styles.module.scss
@@ -65,7 +65,8 @@
     }
 
     @media only screen and (min-width: 996px) {
-        display: block;
+        display: flex;
+        justify-content: flex-end;
     }
 }
 


### PR DESCRIPTION
This PR fixes on FF the hero BG not aligning to the right side of the screen

![image](https://user-images.githubusercontent.com/29581184/231759238-07059ad4-5307-4817-8aad-19b7b18b6c27.png)
