### PR TITLE
make API key the primary term

### DIFF
--- a/docs/endpoints/post-identity-buckets.md
+++ b/docs/endpoints/post-identity-buckets.md
@@ -23,7 +23,7 @@ Used by: This endpoint is used mainly by advertisers and data providers. For det
 | :--- | :--- | :--- | :--- |
 | `{environment}` | string | Required | Testing environment: `https://operator-integ.uidapi.com`<br/>Production environment: `https://prod.uidapi.com`<br/>For a full list, including regional operators, see [Environments](../getting-started/gs-environments.md). |
 
->NOTE: The integration environment and the production environment require different [API keys](../ref-info/glossary-uid.md#gl-client-key).
+>NOTE: The integration environment and the production environment require different [API keys](../ref-info/glossary-uid.md#gl-api-key).
 
 ### Unencrypted JSON Body Parameters
 

--- a/docs/endpoints/post-identity-map.md
+++ b/docs/endpoints/post-identity-map.md
@@ -32,7 +32,7 @@ Here's what you need to know:
 | :--- | :--- | :--- | :--- |
 | `{environment}` | string | Required | Testing environment: `https://operator-integ.uidapi.com`<br/>Production environment: `https://prod.uidapi.com`<br/>For a full list, including regional operators, see [Environments](../getting-started/gs-environments.md). |
 
->NOTE: The integration environment and the production environment require different [API keys](../ref-info/glossary-uid.md#gl-client-key).
+>NOTE: The integration environment and the production environment require different [API keys](../ref-info/glossary-uid.md#gl-api-key).
 
 ###  Unencrypted JSON Body Parameters
 

--- a/docs/endpoints/post-token-generate.md
+++ b/docs/endpoints/post-token-generate.md
@@ -26,7 +26,7 @@ Here's what you need to know about this endpoint requests:
 | :--- | :--- | :--- | :--- |
 | `{environment}` | string | Required | Testing environment: `https://operator-integ.uidapi.com`<br/>Production environment: `https://prod.uidapi.com`<br/>For a full list, including regional operators, see [Environments](../getting-started/gs-environments.md). |
 
->NOTE: The integration environment and the production environment require different [API keys](../ref-info/glossary-uid.md#gl-client-key).
+>NOTE: The integration environment and the production environment require different [API keys](../ref-info/glossary-uid.md#gl-api-key).
 
 ###  Unencrypted JSON Body Parameters
 

--- a/docs/endpoints/post-token-refresh.md
+++ b/docs/endpoints/post-token-refresh.md
@@ -29,7 +29,7 @@ Here's what you need to know about this endpoint:
 | :--- | :--- | :--- | :--- |
 | `{environment}` | string | Required | Testing environment: `https://operator-integ.uidapi.com`<br/>Production environment: `https://prod.uidapi.com`<br/>For a full list, including regional operators, see [Environments](../getting-started/gs-environments.md). |
 
->NOTE: The integration environment and the production environment require different [API keys](../ref-info/glossary-uid.md#gl-client-key).
+>NOTE: The integration environment and the production environment require different [API keys](../ref-info/glossary-uid.md#gl-api-key).
 
 #### Testing Notes
 

--- a/docs/endpoints/post-token-validate.md
+++ b/docs/endpoints/post-token-validate.md
@@ -25,7 +25,7 @@ Used by: This endpoint is used mainly by publishers.
 | :--- | :--- | :--- | :--- |
 | `{environment}` | string | Required | Testing environment: `https://operator-integ.uidapi.com`<br/>Production environment: `https://prod.uidapi.com`<br/>For a full list, including regional operators, see [Environments](../getting-started/gs-environments.md). |
 
->NOTE: The integration environment and the production environment require different [API keys](../ref-info/glossary-uid.md#gl-client-key).
+>NOTE: The integration environment and the production environment require different [API keys](../ref-info/glossary-uid.md#gl-api-key).
 
 
 ###  Unencrypted JSON Body Parameters

--- a/docs/getting-started/gs-api-keys.md
+++ b/docs/getting-started/gs-api-keys.md
@@ -7,14 +7,15 @@ sidebar_position: 03
 
 # API Keys
 
-Each UID2 <a href="/docs/intro#participants">participant</a> has a client key, also called an API key. Each key has a corresponding [client secret](../ref-info/glossary-uid.md#gl-client-secret), a value known only to the participant and the UID2 service.
+Each UID2 <a href="/docs/intro#participants">participant</a> has an API key, also called a client key. Each key has a corresponding [client secret](../ref-info/glossary-uid.md#gl-client-secret), a value known only to the participant and the UID2 service.
 
-The client key and client secret allow the participant to connect to the [Operator Service](../ref-info/glossary-uid.md#gl-operator-service) and call API endpoints. These values identify the participant to the service.
+The API key and client secret allow the participant to connect to the [Operator Service](../ref-info/glossary-uid.md#gl-operator-service) and call API endpoints. These values identify the participant to the service.
 
 Here is some information about API keys and client secrets:
 - One UID2 participant can have multiple keys.
 - Each key has a set of permissions that determine which endpoints it can be used on.
 - Each key has a corresponding client secret.
-- Most API endpoints require both client key and client secret for authentication. For details, see [Authentication and Authorization](gs-auth.md).
+- Most API endpoints require both API key and client secret for authentication. For details, see [Authentication and Authorization](gs-auth.md).
+- If you're using the integration environment as well as the production environment, you'll require separate API keys for each environment.
 
 As part of getting your UID2 account set up, one or more API keys, each with a corresponding client secret, will be issued to you. For details of who to talk to, see [Contact Info](gs-account-setup.md#contact-info).

--- a/docs/getting-started/gs-environments.md
+++ b/docs/getting-started/gs-environments.md
@@ -21,4 +21,4 @@ The following table lists all current testing and production environments for UI
 
 For example, `https://operator-integ.uidapi.com/v2/token/generate`.
 
->NOTE: The integration environment and the production environment require different [API keys](../ref-info/glossary-uid.md#gl-client-key).
+>NOTE: The integration environment and the production environment require different [API keys](../ref-info/glossary-uid.md#gl-api-key).

--- a/docs/ref-info/glossary-uid.md
+++ b/docs/ref-info/glossary-uid.md
@@ -22,6 +22,7 @@ sidebar_position: 10
 <td>
 <ul>
 <li><a href="#gl-advertising-id">Advertising ID</a></li>
+<li><a href="#gl-api-key">API key</a></li>
 <li><a href="#gl-advertising-token">Advertising token</a></li>
 <li><a href="#gl-authorization-header">Authorization header</a></li>
 <li><a href="#gl-bearer-token">Bearer token</a></li>
@@ -92,7 +93,8 @@ sidebar_position: 10
 <dd>Advertising token is another term for a <a href="#gl-uid2-token">UID2 token</a>.</dd>
 
 <dt class="jump-anchor" id="gl-api-key">API key</dt>
-<dd>See <a href="#gl-client-key">Client key</a>.</dd>
+<dd>Each UID2 <a href="/docs/intro#participants">participant</a> has an API key (client key) and also a secret value associated with the key, called the client secret. The client secret is known only to the participant and the UID2 service.</dd>
+<dd>For details, see <a href="/docs/getting-started/gs-api-keys">API Keys</a>.</dd>
 
 <dt class="jump-anchor" id="gl-authorization-header">Authorization header</dt>
 <dd>The Authorization header is a way to authenticate the client to the UID2 service.</dd>
@@ -102,11 +104,10 @@ sidebar_position: 10
 <dd>A bearer token is a special string that identifies the client. For authentication, some UID2 endpoints require the <a href="#gl-client-key">client key</a> to be specified as a bearer token in the Authorization header of the request: for example, <a href="../endpoints/post-token-generate">POST&nbsp;/token/generate</a>.</dd>
 
 <dt class="jump-anchor" id="gl-client-key">Client key</dt>
-<dd>Each UID2 <a href="/docs/intro#participants">participant</a> has a client key, also called API key, that allows the participant to connect to the <a href="#gl-operator-service">Operator Service</a> and call API endpoints. The client key identifies the participant to the UID2 service.</dd>
-<dd>For details, see <a href="/docs/getting-started/gs-api-keys">API Keys</a>.</dd>
+<dd>See <a href="#gl-api-key">API key</a>.</dd>
 
 <dt class="jump-anchor" id="gl-client-secret">Client secret</dt>
-<dd>Each UID2 <a href="/docs/intro#participants">participant</a> has a client key (API key) and also a secret value associated with the key, called the client secret. The client secret is known only to the participant and the UID2 service.</dd>
+<dd>Each UID2 <a href="/docs/intro#participants">participant</a> has an API key (client key) and also a secret value associated with the key, called the client secret. The client secret is known only to the participant and the UID2 service.</dd>
 <dd>For details, see <a href="/docs/getting-started/gs-api-keys">API Keys</a>.</dd>
 
 <dt class="jump-anchor" id="gl-closed-operator">Closed operator</dt>

--- a/docs/summary-doc-v2.md
+++ b/docs/summary-doc-v2.md
@@ -14,6 +14,6 @@ For details on using the API, see the following pages.
 | Documentation | Content Description |
 | :--- | :--- |
 | [Encrypting Requests and Decrypting Responses](getting-started/gs-encryption-decryption.md) | The high-level request-response workflow for the UID2 APIs, requirements for encrypting requests and decrypting responses, and respective script examples in Python.  |
-| [Endpoints](endpoints/summary-endpoints.md) | The API reference for managing identity tokens and mapping email addresses, phone numbers, or hashes to their UID2s and salt bucket IDs used to generate the UID2s.<br/>NOTE: The integration environment and the production environment require different [API keys](ref-info/glossary-uid.md#gl-client-key). |
+| [Endpoints](endpoints/summary-endpoints.md) | The API reference for managing identity tokens and mapping email addresses, phone numbers, or hashes to their UID2s and salt bucket IDs used to generate the UID2s.<br/>NOTE: The integration environment and the production environment require different [API keys](ref-info/glossary-uid.md#gl-api-key). |
 | [Integration Guides](guides/summary-guides.md) | The UID2 integration workflows for UID2 participants, such as publishers, DSPs, advertisers, and data providers, as well as Operator Enterprise Partners, such as Microsoft Azure, AWS, and Snowflake. |
 | [SDKs](sdks/summary-sdks.md) | Links to documentation for using UID2 SDKs. | 


### PR DESCRIPTION
Mods to glossary and other files to make API key the primary term