### PR TITLE
glossary add (API secret)

### DIFF
--- a/docs/ref-info/glossary-uid.md
+++ b/docs/ref-info/glossary-uid.md
@@ -23,6 +23,7 @@ sidebar_position: 10
 <ul>
 <li><a href="#gl-advertising-id">Advertising ID</a></li>
 <li><a href="#gl-api-key">API key</a></li>
+<li><a href="#gl-api-secret">API secret</a></li>
 <li><a href="#gl-advertising-token">Advertising token</a></li>
 <li><a href="#gl-authorization-header">Authorization header</a></li>
 <li><a href="#gl-bearer-token">Bearer token</a></li>
@@ -93,8 +94,11 @@ sidebar_position: 10
 <dd>Advertising token is another term for a <a href="#gl-uid2-token">UID2 token</a>.</dd>
 
 <dt class="jump-anchor" id="gl-api-key">API key</dt>
-<dd>Each UID2 <a href="/docs/intro#participants">participant</a> has an API key (client key) and also a secret value associated with the key, called the client secret. The client secret is known only to the participant and the UID2 service.</dd>
+<dd>Each UID2 <a href="/docs/intro#participants">participant</a> has an API key (client key) and also a secret value associated with the key, called the client secret (API secret). The client secret is known only to the participant and the UID2 service.</dd>
 <dd>For details, see <a href="/docs/getting-started/gs-api-keys">API Keys</a>.</dd>
+
+<dt class="jump-anchor" id="gl-api-secret">API secret</dt>
+<dd>See <a href="#gl-client-secret">client secret</a>.</dd>
 
 <dt class="jump-anchor" id="gl-authorization-header">Authorization header</dt>
 <dd>The Authorization header is a way to authenticate the client to the UID2 service.</dd>
@@ -107,7 +111,7 @@ sidebar_position: 10
 <dd>See <a href="#gl-api-key">API key</a>.</dd>
 
 <dt class="jump-anchor" id="gl-client-secret">Client secret</dt>
-<dd>Each UID2 <a href="/docs/intro#participants">participant</a> has an API key (client key) and also a secret value associated with the key, called the client secret. The client secret is known only to the participant and the UID2 service.</dd>
+<dd>Each UID2 <a href="/docs/intro#participants">participant</a> has an API key (client key) and also a secret value associated with the key, called the client secret (API secret). The client secret is known only to the participant and the UID2 service.</dd>
 <dd>For details, see <a href="/docs/getting-started/gs-api-keys">API Keys</a>.</dd>
 
 <dt class="jump-anchor" id="gl-closed-operator">Closed operator</dt>


### PR DESCRIPTION
Add "API secret" to glossary as a cross-referenced term.