### PR TITLE
fix heading tags on SDK docs

### DIFF
--- a/docs/sdks/uid2-sdk-ref-cplusplus.md
+++ b/docs/sdks/uid2-sdk-ref-cplusplus.md
@@ -22,11 +22,11 @@ You can use UID2 server-side SDKs to facilitate decrypting of UID2 advertising t
 
 The functions outlined here define the information that you'll need to configure or can retrieve from the library. The parameters and property names defined below are pseudocode. Actual parameters and property names vary by language but will be similar to the information outlined here.
 
-# Version
+## Version
 
 The SDK requires C++ version 11.
 
-# SDK Repository
+## SDK Repository
 
 This SDK is available in GitHub: [UID2 SDK for C++](https://github.com/IABTechLab/uid2-client-cpp11/blob/master/README.md).
 

--- a/docs/sdks/uid2-sdk-ref-csharp-dotnet.md
+++ b/docs/sdks/uid2-sdk-ref-csharp-dotnet.md
@@ -22,11 +22,11 @@ You can use UID2 server-side SDKs to facilitate decrypting of UID2 advertising t
 
 The functions outlined here define the information that you'll need to configure or can retrieve from the library. The parameters and property names defined below are pseudocode. Actual parameters and property names vary by language but will be similar to the information outlined here.
 
-# Version
+## Version
 
 The library uses .NET Standard 2.1. unit tests. The sample app uses .NET 5.0.
 
-# SDK Repository
+## SDK Repository
 
 This SDK is available in GitHub: [UID2 SDK for .NET](https://github.com/IABTechLab/uid2-client-net/blob/master/README.md).
 

--- a/docs/sdks/uid2-sdk-ref-java.md
+++ b/docs/sdks/uid2-sdk-ref-java.md
@@ -22,11 +22,11 @@ You can use UID2 server-side SDKs to facilitate decrypting of UID2 advertising t
 
 The functions outlined here define the information that you'll need to configure or can retrieve from the library. The parameters and property names defined below are pseudocode. Actual parameters and property names vary by language but will be similar to the information outlined here.
 
-# Version
+## Version
 
 The SDK requires Java version 1.8 or later.
 
-# SDK Repository
+## SDK Repository
 
 This SDK is available in GitHub: [UID2 SDK for Java](https://github.com/IABTechLab/uid2-client-java/blob/master/README.md).
 

--- a/docs/sdks/uid2-sdk-ref-python.md
+++ b/docs/sdks/uid2-sdk-ref-python.md
@@ -22,11 +22,11 @@ You can use UID2 server-side SDKs to facilitate decrypting of UID2 advertising t
 
 The functions outlined here define the information that you'll need to configure or can retrieve from the library. The parameters and property names defined below are pseudocode. Actual parameters and property names vary by language but will be similar to the information outlined here.
 
-# Version
+## Version
 
 The SDK supports Python 3.6 and above.
 
-# SDK Repository
+## SDK Repository
 
 This SDK is available in GitHub: [UID2 SDK for Python](https://github.com/IABTechLab/uid2-client-python/blob/master/README.md).
 


### PR DESCRIPTION
Fixed some sections that were tagged with h1, should be h2.