### PR TITLE
updates to left nav metadata for SDK guides

### DIFF
--- a/docs/sdks/client-side-identity.md
+++ b/docs/sdks/client-side-identity.md
@@ -1,6 +1,6 @@
 ---
 title: UID2 SDK for JavaScript
-description: Reference information about the JavaScript SDK.
+description: Reference information about the JavaScript client-side SDK.
 hide_table_of_contents: false
 sidebar_position: 02
 ---

--- a/docs/sdks/uid2-sdk-ref-cplusplus.md
+++ b/docs/sdks/uid2-sdk-ref-cplusplus.md
@@ -1,5 +1,5 @@
 ---
-title: UID2 SDK for C++ (Server-Side) Reference Guide
+title: UID2 SDK for C++
 description: Reference information about the C++ server-side SDs.
 hide_table_of_contents: false
 sidebar_position: 04

--- a/docs/sdks/uid2-sdk-ref-csharp-dotnet.md
+++ b/docs/sdks/uid2-sdk-ref-csharp-dotnet.md
@@ -1,5 +1,5 @@
 ---
-title: UID2 SDK for C#/.NET (Server-Side) Reference Guide
+title: UID2 SDK for C#/.NET
 description: Reference information about the C#/.NET server-side SDK.
 hide_table_of_contents: false
 sidebar_position: 03

--- a/docs/sdks/uid2-sdk-ref-java.md
+++ b/docs/sdks/uid2-sdk-ref-java.md
@@ -1,5 +1,5 @@
 ---
-title: UID2 SDK for Java (Server-Side) Reference Guide
+title: UID2 SDK for Java
 description: Reference information about the Java server-side SDK.
 hide_table_of_contents: false
 sidebar_position: 05

--- a/docs/sdks/uid2-sdk-ref-python.md
+++ b/docs/sdks/uid2-sdk-ref-python.md
@@ -1,5 +1,5 @@
 ---
-title: UID2 SDK for Python (Server-Side) Reference Guide
+title: UID2 SDK for Python
 description: Reference information about the Python server-side SDK.
 hide_table_of_contents: false
 sidebar_position: 06


### PR DESCRIPTION
updates to left nav metadata for SDK guides so left nav and landing page copy is shorter and more parallel.