### PR TITLE
UID2-1411 replace Cstg description with something more generic

### DIFF
--- a/docs/guides/integration-prebid-advanced.md
+++ b/docs/guides/integration-prebid-advanced.md
@@ -27,7 +27,7 @@ sidebar_position: 04
 
 This guide is for publishers who want to integrate with UID2 and generate [UID2 tokens](../ref-info/glossary-uid.md#gl-uid2-token) (advertising tokens) to be passed by Prebid in the RTB bid stream. It covers advanced use cases for publishers who want to generate and optionally refresh UID2 tokens by making server-side API calls to the UID2 operator.
 
-For integration instructions that do not require server-side changes, see [Prebid.js Integration Guide](./integration-prebid.md).
+For integration instructions that do not require server-side changes, see [Prebid.js Express Integration Guide](./integration-prebid.md).
 
 This guide outlines the basic steps to consider if you're building a direct integration with UID2 and you use Prebid for header bidding. 
 

--- a/docs/guides/integration-prebid.md
+++ b/docs/guides/integration-prebid.md
@@ -1,6 +1,6 @@
 ---
-title: Prebid.js Integration
-sidebar_label: Prebid.js
+title: Prebid.js Express Integration
+sidebar_label: Prebid.js Express Integration
 pagination_label: Prebid.js Integration
 description: Information about integrating with Prebid.js as part of your UID2 implementation.
 hide_table_of_contents: false

--- a/docs/guides/integration-prebid.md
+++ b/docs/guides/integration-prebid.md
@@ -1,7 +1,7 @@
 ---
 title: Prebid.js Express Integration
 sidebar_label: Prebid.js Express Integration
-pagination_label: Prebid.js Integration
+pagination_label: Prebid.js Express Integration
 description: Information about integrating with Prebid.js as part of your UID2 implementation.
 hide_table_of_contents: false
 sidebar_position: 04

--- a/docs/guides/integration-prebid.md
+++ b/docs/guides/integration-prebid.md
@@ -7,7 +7,7 @@ hide_table_of_contents: false
 sidebar_position: 04
 ---
 
-# Prebid.js Integration Guide
+# Prebid.js Express Integration Guide
 
 This guide is for publishers who want to integrate with UID2 and generate [UID2 tokens](../ref-info/glossary-uid.md#gl-uid2-token) (advertising tokens) to be passed by Prebid.js in the RTB bid stream.
 

--- a/docs/guides/summary-guides.md
+++ b/docs/guides/summary-guides.md
@@ -30,11 +30,11 @@ Publisher integrations fall into the following main categories:
 
 The following resources are available for publisher web integrations.
 
-| Integration Guide |  Content Description |
-| :--- | :--- |
-| [Prebid.js Integration Guide](./integration-prebid.md) | An integration guide for publishers who want to integrate with UID2 and generate identity tokens to be passed by Prebid in the RTB bid stream. This guide is for publishers who want to request UID2 tokens client-side, which is the easiest implementation approach. |
-| [Prebid.js Advanced Integration Guide](./integration-prebid-advanced.md) | An integration guide for publishers who want to integrate with UID2 and generate identity tokens to be passed by Prebid in the RTB bid stream. This guide is for publishers who are using a private operator or who want to generate tokens server-side. |
-| [UID2 SDK for JavaScript Integration Guide](publisher-client-side.md) | This integration guide for publishers covers standard web integration scenarios that use the UID2 SDK for JavaScript. |
+| Integration Guide                                                           |  Content Description |
+|:----------------------------------------------------------------------------| :--- |
+| [Prebid.js Express Integration Guide](./integration-prebid.md)              | An integration guide for publishers who want to integrate with UID2 and generate identity tokens to be passed by Prebid in the RTB bid stream. This guide is for publishers who want to request UID2 tokens client-side, which is the easiest implementation approach. |
+| [Prebid.js Advanced Integration Guide](./integration-prebid-advanced.md)    | An integration guide for publishers who want to integrate with UID2 and generate identity tokens to be passed by Prebid in the RTB bid stream. This guide is for publishers who are using a private operator or who want to generate tokens server-side. |
+| [UID2 SDK for JavaScript Integration Guide](publisher-client-side.md)       | This integration guide for publishers covers standard web integration scenarios that use the UID2 SDK for JavaScript. |
 | [Publisher Integration Guide, Server-Only](custom-publisher-integration.md) | This integration guide is for publishers that do not use the UID2 SDK for JavaScript. |
 
 ### Mobile

--- a/docs/overviews/overview-publishers.md
+++ b/docs/overviews/overview-publishers.md
@@ -46,11 +46,11 @@ The following documentation resources are available for publishers to implement 
 
 The following resources are available for publisher web integrations.
 
-| Integration Type | Integration Guide |  Content Description | Audience |
-| :---| :--- | :--- | :--- |
-| Prebid | [Prebid.js Integration Guide](../guides/integration-prebid.md) | An integration guide for publishers who want to integrate with UID2 and generate identity tokens to be passed by Prebid in the RTB bid stream. This guide is for publishers who want to request UID2 tokens client-side, which is the easiest implementation approach. | Publishers |
-| Prebid | [Prebid.js Advanced Integration Guide](../guides/integration-prebid-advanced.md) | An integration guide for publishers who want to integrate with UID2 and generate identity tokens to be passed by Prebid in the RTB bid stream. This guide is for publishers who are using a private operator or who want to generate tokens server-side. | Publishers |
-| Client-Side (Web) Integration | [UID2 SDK for JavaScript Integration Guide](../guides/publisher-client-side.md) | This integration guide for publishers covers standard web integration scenarios that use the UID2 SDK for JavaScript. | Publishers |
+| Integration Type | Integration Guide                                                                     |  Content Description | Audience |
+| :---|:--------------------------------------------------------------------------------------| :--- | :--- |
+| Prebid | [Prebid.js Express Integration Guide](../guides/integration-prebid.md)                | An integration guide for publishers who want to integrate with UID2 and generate identity tokens to be passed by Prebid in the RTB bid stream. This guide is for publishers who want to request UID2 tokens client-side, which is the easiest implementation approach. | Publishers |
+| Prebid | [Prebid.js Advanced Integration Guide](../guides/integration-prebid-advanced.md)      | An integration guide for publishers who want to integrate with UID2 and generate identity tokens to be passed by Prebid in the RTB bid stream. This guide is for publishers who are using a private operator or who want to generate tokens server-side. | Publishers |
+| Client-Side (Web) Integration | [UID2 SDK for JavaScript Integration Guide](../guides/publisher-client-side.md)       | This integration guide for publishers covers standard web integration scenarios that use the UID2 SDK for JavaScript. | Publishers |
 | Server-Side Integration  | [Publisher Integration Guide, Server-Only](../guides/custom-publisher-integration.md) | This integration guide is for publishers that do not use the [UID2 SDK for JavaScript Reference Guide](../sdks/client-side-identity.md). | Publishers |
 
 

--- a/docs/ref-info/updates-doc.md
+++ b/docs/ref-info/updates-doc.md
@@ -13,12 +13,12 @@ Check out the latest updates to our UID2 documentation resources.
 
 2 November 2023
 
-The Prebid.js Integration Guide is a completely new document at the existing URL, covering a new, simpler way of integrating UID2 with Prebid that does not require any server-side work.
+The Prebid.js Express Integration Guide is a completely new document at the existing URL, covering a new, simpler way of integrating UID2 with Prebid that does not require any server-side work.
 
 The content that was in the previous version of the Prebid document is now in a supplementary document, *Prebid.js Advanced Integration Guide*, for publishers who are using a private operator or who prefer to implement token generate on the server side.
 
 For details, see:
-- [Prebid.js Integration Guide](../guides/integration-prebid.md)
+- [Prebid.js Express Integration Guide](../guides/integration-prebid.md)
 - [Prebid.js Advanced Integration Guide](../guides/integration-prebid-advanced.md)
 
 ### New: Opt-Out

--- a/i18n/ja/docusaurus-plugin-content-docs/current/guides/integration-prebid.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/guides/integration-prebid.md
@@ -7,7 +7,7 @@ hide_table_of_contents: false
 sidebar_position: 04
 ---
 
-# Prebid.js Integration Guide
+# Prebid.js Express Integration Guide
 
 This guide is for publishers who want to integrate with UID2 and generate [UID2 tokens](../ref-info/glossary-uid.md#gl-uid2-token) (advertising tokens) to be passed by Prebid.js in the RTB bid stream.
 

--- a/static/examples/cstg-prebid-example/README.md
+++ b/static/examples/cstg-prebid-example/README.md
@@ -1,6 +1,8 @@
-# Prebid.js UID2 with client-side token generation
+# Example Prebid.js UID2 Integration
 
 ## Viewing live site
+
+This example demonstrates the Prebid.js Express Integration guide [here](https://unifiedid.com/docs/guides/integration-prebid). 
 
 To view the site running, navigate to [https://unifiedid.com/examples/cstg-prebid-example/](https://unifiedid.com/examples/cstg-prebid-example/).
 
@@ -12,4 +14,4 @@ When running locally, the configuration values in `index.html` will not work, as
 
 ## Prebid.js
 
-This file is a build of Prebid.js for the CSTG example, with the userId, uid2IdSystem, appnexusBidAdapter modules included.
+This file is a build of Prebid.js with the userId, uid2IdSystem, appnexusBidAdapter modules included.

--- a/static/examples/cstg-prebid-example/README.md
+++ b/static/examples/cstg-prebid-example/README.md
@@ -2,7 +2,7 @@
 
 ## Viewing live site
 
-This example demonstrates the Prebid.js Express Integration guide [here](https://unifiedid.com/docs/guides/integration-prebid). 
+This example demonstrates the [Prebid.js Express Integration guide](https://unifiedid.com/docs/guides/integration-prebid). 
 
 To view the site running, navigate to [https://unifiedid.com/examples/cstg-prebid-example/](https://unifiedid.com/examples/cstg-prebid-example/).
 
@@ -14,4 +14,4 @@ When running locally, the configuration values in `index.html` will not work, as
 
 ## Prebid.js
 
-This file is a build of Prebid.js with the userId, uid2IdSystem, appnexusBidAdapter modules included.
+This file is a build of Prebid.js with the userId, uid2IdSystem and appnexusBidAdapter modules included.

--- a/static/examples/cstg-prebid-example/index.html
+++ b/static/examples/cstg-prebid-example/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>UID2 Prebid.js CSTG Integration Example</title>
+    <title>UID2 Prebid.js Express Integration Example</title>
     <link rel="stylesheet" type="text/css" href="./app.css" />
     <link rel="shortcut icon" href="/img/favicon.ico" />
     <script async src="./prebid.js"></script>
@@ -106,10 +106,9 @@
     </script>
   </head>
   <body>
-    <h1>UID2 Prebid.js CSTG Integration Example</h1>
+    <h1>UID2 Prebid.js Express Integration Example</h1>
     <p class="intro">
-      This example demonstrates how a content publisher can use the <a href="https://unifiedid.com/docs/guides/integration-prebid">Prebid.js UID2 module</a>
-      to generate client-side UID2 advertising tokens.
+      This example demonstrates how a content publisher can integrate with UID2 and Prebid.js using <a href="https://unifiedid.com/docs/guides/integration-prebid">the Express Integration Guide</a>, which includes generating UID2 tokens within the browser.
     </p>
     <table id="uid2_state">
       <tr>

--- a/static/examples/cstg-prebid-example/index.html
+++ b/static/examples/cstg-prebid-example/index.html
@@ -108,7 +108,7 @@
   <body>
     <h1>UID2 Prebid.js Express Integration Example</h1>
     <p class="intro">
-      This example demonstrates how a content publisher can integrate with UID2 and Prebid.js using <a href="https://unifiedid.com/docs/guides/integration-prebid">the Express Integration Guide</a>, which includes generating UID2 tokens within the browser.
+      This example demonstrates how a content publisher can integrate with UID2 and Prebid.js using the <a href="https://unifiedid.com/docs/guides/integration-prebid">Prebid.js Express Integration Guide</a>, which includes generating UID2 tokens within the browser.
     </p>
     <table id="uid2_state">
       <tr>


### PR DESCRIPTION
replace Cstg description with something more generic and renamed prebid integration guide to Prebid.js Express Integration Guide so it's easier to differentiate between the normal/Express guide versus the Advanaced Integration guide (calling it Standard/default doesn't sound as nice/quick as Express