### PR TITLE
refactor: :recycle: update HTML lang attr for ja

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -56,7 +56,7 @@ const config = {
       ja: {
         label: "日本語",
         direction: "ltr",
-        htmlLang: "jp-JP",
+        htmlLang: "ja",
         calendar: "japanese",
       },
     },


### PR DESCRIPTION
Refactored the Japanese version of the site to use `ja`  instead of  `jp-JP` in the HTML land attribute. This should fire the one trust banner in Japanese now. 