### PR TITLE
fix: :bug: remove duplicate header + h1 from docs

### DIFF
--- a/src/components/DocsBanner/index.tsx
+++ b/src/components/DocsBanner/index.tsx
@@ -12,6 +12,14 @@ export default function DocsBanner({
   title,
   description,
 }: DocsBannerProps): JSX.Element {
+  //remove the dulpicate html <header> + h1 tags within the .markdown
+  React.useEffect(() => {
+    const header = document.querySelector(".markdown > header");
+    if (header) {
+      header.remove();
+    }
+  }, []);
+
   return (
     <header className={clsx(styles.docsBanner)}>
       <div className={styles.docsBannerLeft}>


### PR DESCRIPTION
If the <DocsBanner> component is displayed, it will remove the duplicate header + h1 below it automatically generated by Docusaurus. 