### PR TITLE
fix error in MD syntax in jpn translation update #398

### DIFF
--- a/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/gs-encryption-decryption.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/gs-encryption-decryption.md
@@ -414,8 +414,8 @@ public class Uid2Request {
     System.out.println("Response JSON:");
     System.out.println(prettyJsonResponse);
   }
-}```
-
+}
+```
 </TabItem>
 <TabItem value='cs' label='C#'>
 


### PR DESCRIPTION
Fixed a bug in gs-encryption-decryption.md where C# code was not displayed.