### PR TITLE
JS SDK doc, move payloads out of table to code tags

### DIFF
--- a/docs/sdks/client-side-identity.md
+++ b/docs/sdks/client-side-identity.md
@@ -192,9 +192,27 @@ The following example callback handles the `SdkLoaded` event to call init and th
 
 | Event | Payload | Details |
 | :--- | :--- | :--- |
-| `SdkLoaded` | {} | Called when the SDK script has loaded and the global `__uid2` has been constructed. When you receive this event, it is safe to call `__uid2.init`. Callbacks always receive this event once. If the SDK has already been loaded when the callback is registered, it receives the event immediately. |
-| `InitCompleted` | `{ identity: Uid2Identity  \| null }` | Called once `init()` has finished. Callbacks always receive this event once, as long as a successful call to `init` has been made. If `init` has already been completed when the callback is registered, it receives this immediately after it receives the `SdkLoaded` event. |
-| `IdentityUpdated` | `{ identity: Uid2Identity \| null }` | Called whenever the current identity changes. If the identity doesn't change after the callback is registered, callbacks do not receive this event. |
+| `SdkLoaded` | See [Payload for SdkLoaded](#payload-for-sdkloaded) | Called when the SDK script has loaded and the global `__uid2` has been constructed. When you receive this event, it is safe to call `__uid2.init`. Callbacks always receive this event once. If the SDK has already been loaded when the callback is registered, it receives the event immediately. |
+| `InitCompleted` | See [Payload for InitCompleted](#payload-for-initcompleted) | Called once `init()` has finished. Callbacks always receive this event once, as long as a successful call to `init` has been made. If `init` has already been completed when the callback is registered, it receives this immediately after it receives the `SdkLoaded` event. |
+| `IdentityUpdated` | See [Payload for IdentityUpdated](#payload-for-identityupdated) | Called whenever the current identity changes. If the identity doesn't change after the callback is registered, callbacks do not receive this event. |
+
+##### Payload for SdkLoaded:
+
+```
+{}
+```
+
+##### Payload for InitCompleted:
+
+```
+{ identity: Uid2Identity  \| null }
+```
+
+##### Payload for IdentityUpdated:
+
+```
+{ identity: Uid2Identity \| null } 
+```
 
 The `Uid2Identity` type is the same type as the identity you can provide when calling `init()`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9359,9 +9359,9 @@
       "devOptional": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",


### PR DESCRIPTION
JS SDK doc, move payloads out of table to code tags
NOTE there is a new package-lock.json. Need your input re whether we should have this. Thx.
(closing as LLP's PR 424 is a better resolution to this issue).