### PR TITLE
refactor: :recycle: Convert swizzled theme provider to TS

### DIFF
--- a/src/theme/Layout/Provider/index.tsx
+++ b/src/theme/Layout/Provider/index.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect } from "react";
-import { composeProviders, useColorMode } from "@docusaurus/theme-common";
+import {
+  composeProviders,
+  useColorMode,
+  ColorMode,
+} from "@docusaurus/theme-common";
 import { useLocation } from "@docusaurus/router";
 import {
   ColorModeProvider,
@@ -21,7 +25,7 @@ const Provider = composeProviders([
 function RestoreTheme() {
   const { setColorMode } = useColorMode();
   useEffect(() => {
-    const storedTheme = localStorage.getItem("theme");
+    const storedTheme = localStorage.getItem("theme") as ColorMode;
     setColorMode(storedTheme);
   }, []);
   return <></>;
@@ -29,7 +33,7 @@ function RestoreTheme() {
 
 export default function LayoutProvider({ children }) {
   const location = useLocation();
-  let isDocsPage = location.pathname.includes("/docs/");
+  const isDocsPage = location.pathname.includes("/docs/");
 
   return (
     <Provider>


### PR DESCRIPTION
Changed `src/theme/Layout/Provider/index.js` to `src/theme/Layout/Provider/index.tsx` and cleaned up minor TS warnings on the page