### PR TITLE
Make all non-full sidebars use refs so nothing actually "belongs" to …

### DIFF
--- a/docs/endpoints/summary-endpoints.md
+++ b/docs/endpoints/summary-endpoints.md
@@ -3,6 +3,7 @@ title: UID2 Endpoints - Summary
 description: Summary of the endpoints available in the UID2 service.
 hide_table_of_contents: false
 sidebar_position: 01
+displayed_sidebar: docs
 ---
 
 # UID2 Endpoints: Summary

--- a/docs/guides/integration-options-publisher-web.md
+++ b/docs/guides/integration-options-publisher-web.md
@@ -3,6 +3,7 @@ title: Web Integration Overview
 description: Overview of the publisher options for UID2 web integration.
 hide_table_of_contents: false
 sidebar_position: 02
+displayed_sidebar: sidebarPublishers
 ---
 
 # Web Integration Overview

--- a/docs/guides/integration-prebid.md
+++ b/docs/guides/integration-prebid.md
@@ -5,6 +5,7 @@ pagination_label: UID2 Integration Overview for Prebid.js
 description: Overview of options for integrating with Prebid.js as part of your UID2 implementation.
 hide_table_of_contents: false
 sidebar_position: 04
+displayed_sidebar: sidebarPublishers
 ---
 
 # UID2 Integration Overview for Prebid.js

--- a/docs/guides/summary-guides.md
+++ b/docs/guides/summary-guides.md
@@ -5,6 +5,7 @@ pagination_label: UID2 Integration Guides - Summary
 description: Summary of all the integration guides available.
 hide_table_of_contents: false
 sidebar_position: 01
+displayed_sidebar: docs
 ---
 
 # UID2 Integration Guides: Summary

--- a/docs/portal/portal-overview.md
+++ b/docs/portal/portal-overview.md
@@ -3,6 +3,7 @@ title: UID2 Portal - Overview
 description: General information about the UID2 Portal.
 hide_table_of_contents: false
 sidebar_position: 01
+displayed_sidebar: docs
 ---
 
 # UID2 Portal: Overview

--- a/docs/sdks/summary-sdks.md
+++ b/docs/sdks/summary-sdks.md
@@ -5,6 +5,7 @@ pagination_label: SDKs - Summary
 description: Summary of SDK documentation available.
 hide_table_of_contents: false
 sidebar_position: 01
+displayed_sidebar: docs
 ---
 
 # SDKs: Summary

--- a/docs/sharing/sharing-overview.md
+++ b/docs/sharing/sharing-overview.md
@@ -3,6 +3,7 @@ title: Overview of Sharing
 description: Learn about sharing UID2s with other participants.
 hide_table_of_contents: false
 sidebar_position: 01
+displayed_sidebar: docs
 ---
 
 # UID2 Sharing: Overview 

--- a/sidebars.js
+++ b/sidebars.js
@@ -1,9 +1,11 @@
 function removeItems(sidebar, ...remove) {
   const result = [];
   for (let item of sidebar) {
-    if (typeof item === 'string') 
+    if (typeof item === 'string')
     {
-      if (!remove.includes(item)) result.push(item);
+      if (!remove.includes(item)) result.push({
+        type: 'ref', id: item
+      });
     }
     else {
       if (!remove.includes(item.label)) {


### PR DESCRIPTION
…them.

N.B. docusaurus doesn't let us use refs for category links, so anything that's a category link needs to be specifically put in the docs sidebar using front matter.