### PR TITLE
feat: :mag: stop indexing of URL params

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,4 +1,7 @@
 User-agent: *
 Allow: /
 
+# Disallowing indexing or URLs with query parameters
+Disallow: /*?
+
 Sitemap: https://unifiedid.com/sitemap.xml


### PR DESCRIPTION
Looks like some weird URLs related to careers job postings are being generated and creating "new" URLs that google is crawling and linking to UID2 which google search console is flagging. While we do have canonical URLs in place which already solves this issue,  we can also disallow the pages from being indexed. 

`Disallow: /*?`

This will effectively prevent Google from crawling any parameterized URL in the future which should lead to fewer of these issues popping up which has been added to the robots.txt