### PR TITLE
fix: :bug: GTM event firing 4 times on page load

### DIFF
--- a/src/pages/partners.tsx
+++ b/src/pages/partners.tsx
@@ -59,33 +59,22 @@ const componentData = {
 };
 
 const dspPartners = partnersData.filter((partner) =>
-  partner.type.includes("DSP")
+  partner.type.includes("DSP"),
 );
 
 const publishersPartners = partnersData.filter((partner) =>
-  partner.type.includes("Publishers")
+  partner.type.includes("Publishers"),
 );
 
 const dataPartners = partnersData.filter((partner) =>
-  partner.type.includes("Data")
+  partner.type.includes("Data"),
 );
 
 const cdpPartners = partnersData.filter((partner) =>
-  partner.type.includes("CDP")
+  partner.type.includes("CDP"),
 );
 
 function PartnerSection({ title, partners }: PartnerSection) {
-  React.useEffect(() => {
-    const pageViewData = {
-      event: "Initialize_dataLayer",
-      document_type: "partners",
-      document_title: document.title,
-      article_author: undefined,
-      tags: undefined,
-    };
-
-    pushGtmEvent(pageViewData);
-  }, []);
   return (
     <section className={styles.partnersSection}>
       <div className={clsx("container")}>
@@ -110,6 +99,18 @@ function PartnerSection({ title, partners }: PartnerSection) {
 }
 
 export default function Partners(): JSX.Element {
+  React.useEffect(() => {
+    const pageViewData = {
+      event: "Initialize_dataLayer",
+      document_type: "partners",
+      document_title: document.title,
+      article_author: undefined,
+      tags: undefined,
+    };
+
+    pushGtmEvent(pageViewData);
+  }, []);
+
   return (
     <Layout title={componentData.title} description={componentData.description}>
       <main>


### PR DESCRIPTION
The page_view event was firing four times because it was originally in the wrong function.

Moved it to the page component and is now firing once. 