### PR TITLE
add links from mobile SDK docs to server-only guide

### DIFF
--- a/docs/sdks/uid2-sdk-ref-android.md
+++ b/docs/sdks/uid2-sdk-ref-android.md
@@ -33,6 +33,10 @@ You can use the UID2 SDK for Android for the following:
 - Retrieving advertising tokens for bidstream use.
 - Automatically refreshing UID2 tokens.
 
+:::note
+To generate tokens on the back-end server, follow the instructions in [Publisher Integration Guide, Server-Only](../guides/custom-publisher-integration.md).
+:::
+
 The following Android-related plugins, and associated documentation, are also available.
 
 | Purpose | Product/Documentation |

--- a/docs/sdks/uid2-sdk-ref-ios.md
+++ b/docs/sdks/uid2-sdk-ref-ios.md
@@ -32,6 +32,10 @@ You can use the UID2 SDK for iOS for the following:
 - Retrieving advertising tokens for bidstream use.
 - Automatically refreshing UID2 tokens.
 
+:::note
+To generate tokens on the back-end server, follow the instructions in [Publisher Integration Guide, Server-Only](../guides/custom-publisher-integration.md).
+:::
+
 The following iOS-related plugins, and associated documentation, are also available:
 
 | Purpose | Product/Documentation |


### PR DESCRIPTION
add links from mobile SDK docs to server-only guide
Closing as per SW no longer needed with the new mobile integration guides.