### PR TITLE
clarify sharing permissions page is for tokenized sharing

### DIFF
--- a/docs/portal/sharing-permissions.md
+++ b/docs/portal/sharing-permissions.md
@@ -11,6 +11,10 @@ import Link from '@docusaurus/Link';
 
 Configuring your sharing permissions opens the door to you being able to share UID2s with other UID2 <Link href="../ref-info/glossary-uid#gl-sharing-participant">sharing participants</Link>.
 
+:::tip
+Configuring sharing permissions in the UID2 Portal is for <Link href="../ref-info/glossary-uid#gl-tokenized-sharing">tokenized sharing</Link>, not for sharing raw UID2s. For details, see [UID2 Sharing Approaches](../sharing/sharing-overview.md#uid2-sharing-approaches).
+:::
+
 There are many options to help you create the exact sharing relationships that you want:
 
 - **Recommendations**: You can accept recommendations, with one click, to share with all current and future participants in one or more categories (Publishers, Advertisers, DSPs, or Data Providers). See [Add Sharing Permissions&#8212;Bulk](#add-sharing-permissionsbulk).


### PR DESCRIPTION
Clarify sharing permissions page is for tokenized sharing (req from AT).