### PR TITLE
To GSS doc, add client-side React sample implementation

### DIFF
--- a/docs/guides/integration-google-ss.md
+++ b/docs/guides/integration-google-ss.md
@@ -162,6 +162,9 @@ The following sample implementations are available to illustrate how to integrat
 - Client-side integration example using the UID2 JavaScript SDK with Google secure signals:
   - [Sample implementation](https://secure-signals-client-side-integ.uidapi.com/)
   - [Code repository](https://github.com/IABTechLab/uid2-web-integrations/tree/main/examples/google-secure-signals-integration/client_side)
+- Client-side integration example using React, the UID2 JavaScript SDK, and Google secure signals:
+  - [Sample implementation](https://secure-signals-react-integ.uidapi.com)
+  - [Code repository](https://github.com/IABTechLab/uid2-web-integrations/tree/main/examples/google-secure-signals-integration/react_client_side)
 
 Each sample implementation has its own instructions.
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/guides/integration-google-ss.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/guides/integration-google-ss.md
@@ -120,6 +120,9 @@ Google Ad Manager のセキュアシグナル機能との連携方法につい�
 - Client-side integration example using the UID2 JavaScript SDK with Google secure signals:
   - [Sample implementation](https://secure-signals-client-side-integ.uidapi.com/)
   - [Code repository](https://github.com/IABTechLab/uid2-web-integrations/tree/main/examples/google-secure-signals-integration/client_side)
+- Client-side integration example using React, the UID2 JavaScript SDK, and Google secure signals:
+  - [Sample implementation](https://secure-signals-react-integ.uidapi.com)
+  - [Code repository](https://github.com/IABTechLab/uid2-web-integrations/tree/main/examples/google-secure-signals-integration/react_client_side)
 
 各サンプルアプリケーションには独自のインストラクションがあります。
 


### PR DESCRIPTION
To GSS doc, add client-side React sample implementation
(Same mods in Japanese file. No need to review both -- any edits I will apply to both files)