### PR TITLE
put back redirect file for Python SDK

### DIFF
--- a/docs/sdks/uid2-sdk-ref-python.mdx
+++ b/docs/sdks/uid2-sdk-ref-python.mdx
@@ -1,0 +1,3 @@
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/docs/sdks/sdk-ref-python" />;


### PR DESCRIPTION
put back redirect file for Python SDK since there is an external link pointing to the old filename.