### PR TITLE
ibg-CORPWEB-3437-404-page

### DIFF
--- a/i18n/ja/code.json
+++ b/i18n/ja/code.json
@@ -36,16 +36,28 @@
     "description": "The title of the fallback page when the page crashed"
   },
   "theme.NotFound.title": {
-    "message": "ページが見つかりません",
+    "message": "ページが見つかりませんでした",
     "description": "The title of the 404 page"
   },
   "theme.NotFound.p1": {
-    "message": "お探しのページが見つかりませんでした",
+    "message": "お探しのページが見つかりませんでした。ページが移動したか、リンクにエラーがある可能性があります。",
     "description": "The first paragraph of the 404 page"
   },
   "theme.NotFound.p2": {
-    "message": "このページにリンクしているサイトの所有者にリンクが壊れていることを伝えてください",
+    "message": "以下の方法をお試しください:",
     "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.NotFound.ListItem1": {
+    "message": "リンクを再度クリックしてください。",
+    "description": "The first list item of the 404 page"
+  },
+  "theme.NotFound.ListItem2": {
+    "message": "UID2 のページからタイトルやキーワードで検索してください。",
+    "description": "The second list item of the 404 page"
+  },
+  "theme.NotFound.ListItem3": {
+    "message": "UID2 ドキュメントホームページにアクセスしてください。",
+    "description": "The third list item of the 404 page"
   },
   "theme.admonition.note": {
     "message": "注記",

--- a/src/theme/NotFound/Content/index.tsx
+++ b/src/theme/NotFound/Content/index.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import clsx from "clsx";
+import Translate from "@docusaurus/Translate";
+import type { Props } from "@theme/NotFound/Content";
+import Heading from "@theme/Heading";
+
+export default function NotFoundContent({ className }: Props): JSX.Element {
+  return (
+    <main className={clsx("container margin-vert--xl", className)}>
+      <div className="row">
+        <div className="col col--6 col--offset-3">
+          <Heading as="h1" className="hero__title">
+            <Translate
+              id="theme.NotFound.title"
+              description="The title of the 404 page"
+            >
+              Page Not Found
+            </Translate>
+          </Heading>
+          <p>
+            <Translate
+              id="theme.NotFound.p1"
+              description="The first paragraph of the 404 page"
+            >
+              We could not find what you were looking for.
+            </Translate>
+          </p>
+          <p>
+            <Translate
+              id="theme.NotFound.p2"
+              description="The 2nd paragraph of the 404 page"
+            >
+              Please contact the owner of the site that linked you to the
+              original URL and let them know their link is broken.
+            </Translate>
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/theme/NotFound/Content/index.tsx
+++ b/src/theme/NotFound/Content/index.tsx
@@ -3,6 +3,7 @@ import clsx from "clsx";
 import Translate from "@docusaurus/Translate";
 import type { Props } from "@theme/NotFound/Content";
 import Heading from "@theme/Heading";
+import Link from "@docusaurus/Link";
 
 export default function NotFoundContent({ className }: Props): JSX.Element {
   return (
@@ -22,7 +23,8 @@ export default function NotFoundContent({ className }: Props): JSX.Element {
               id="theme.NotFound.p1"
               description="The first paragraph of the 404 page"
             >
-              We could not find what you were looking for.
+              We couldn't find the page you were looking for. The page might
+              have been moved, or there was an error in the link.
             </Translate>
           </p>
           <p>
@@ -30,10 +32,38 @@ export default function NotFoundContent({ className }: Props): JSX.Element {
               id="theme.NotFound.p2"
               description="The 2nd paragraph of the 404 page"
             >
-              Please contact the owner of the site that linked you to the
-              original URL and let them know their link is broken.
+              Here are some things you can do:
             </Translate>
           </p>
+          <ul>
+            <li>
+              <Translate
+                id="theme.NotFound.ListItem1"
+                description="The first list item of the 404 page"
+              >
+                Go back and retry the link.
+              </Translate>
+            </li>
+            <li>
+              <Translate
+                id="theme.NotFound.ListItem2"
+                description="The second list item of the 404 page"
+              >
+                Search for the document by its title or keywords from any UID2
+                page.
+              </Translate>
+            </li>
+            <li>
+              <Link to="/docs/intro">
+                <Translate
+                  id="theme.NotFound.ListItem3"
+                  description="The third list item of the 404 page"
+                >
+                  Visit the UID2 documentation home page
+                </Translate>
+              </Link>
+            </li>
+          </ul>
         </div>
       </div>
     </main>

--- a/src/theme/NotFound/Content/index.tsx
+++ b/src/theme/NotFound/Content/index.tsx
@@ -59,7 +59,7 @@ export default function NotFoundContent({ className }: Props): JSX.Element {
                   id="theme.NotFound.ListItem3"
                   description="The third list item of the 404 page"
                 >
-                  Visit the UID2 documentation home page
+                  Visit the UID2 documentation home page.
                 </Translate>
               </Link>
             </li>

--- a/src/theme/NotFound/index.tsx
+++ b/src/theme/NotFound/index.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { translate } from "@docusaurus/Translate";
+import { PageMetadata } from "@docusaurus/theme-common";
+import Layout from "@theme/Layout";
+import NotFoundContent from "@theme/NotFound/Content";
+
+export default function Index(): JSX.Element {
+  const title = translate({
+    id: "theme.NotFound.title",
+    message: "Page Not Found",
+  });
+
+  return (
+    <>
+      <PageMetadata title={title} />
+      <Layout>
+        <NotFoundContent />
+      </Layout>
+    </>
+  );
+}


### PR DESCRIPTION
## Changes

- I ran the command to eject the `NotFound` theme component, allowing customization to 404 pages.
  - Command run: `npm run swizzle @docusaurus/theme-classic NotFound`
- Changes to the file `src/theme/NotFound/Content/index.tsx` will be shown on the 404 page.