### PR TITLE
minor edits CTV guide

### DIFF
--- a/docs/guides/integration-ctv-guide.md
+++ b/docs/guides/integration-ctv-guide.md
@@ -54,11 +54,13 @@ The specific values you set up will depend on which of the [CTV integration opti
 
 ## CTV Integration Options
 
-You can decide on the integration option that's best for you based on where you want to generate and refresh the UID2 token. There are three options, as follows:
+You can decide on the integration option that's best for you based on where you want to generate and refresh the UID2 token. There are three options, as shown in the following table.
 
-- [Client-Side Integration](#client-side-integration-for-ctv-apps) (the token is generated and refreshed on the client side)
-- [Server-Side Integration](#server-side-integration-for-ctv-apps) (the token is generated and refreshed on the server side)
-- [Client-Server Integration](#client-server-integration-for-ctv-apps) (the token is generated on the server side and refreshed on the client side)
+| Option | Details |
+| :--- | :--- |
+| [Client-Side Integration](#client-side-integration-for-ctv-apps) | The token is generated and refreshed on the client side. |
+| [Server-Side Integration](#server-side-integration-for-ctv-apps) | The token is generated and refreshed on the server side. |
+| [Client-Server Integration](#client-server-integration-for-ctv-apps) | The token is generated on the server side and refreshed on the client side. |
 
 ### Client-Side Integration for CTV Apps
 

--- a/docs/guides/integration-options-private-operator.md
+++ b/docs/guides/integration-options-private-operator.md
@@ -8,7 +8,7 @@ import Link from '@docusaurus/Link';
 
 # UID2 Private Operator Integration Overview
 
-UID2 participants that host their own <Link href="../ref-info/glossary-uid#gl-private-operator">Private Operator</Link> send their own first-party <Link href="../ref-info/glossary-uid#gl-dii">directly identifying information (DII)</Link> to their own, local UID2 <Link href="../ref-info/glossary-uid#gl-operator">Operator</Link> service, running in a private environment.
+UID2 participants that host their own <Link href="../ref-info/glossary-uid#gl-private-operator">Private Operator</Link> send their own first-party <Link href="../ref-info/glossary-uid#gl-dii">directly identifying information (DII)</Link> to their own local UID2 <Link href="../ref-info/glossary-uid#gl-operator">Operator</Link> service, running in a private environment.
 
 A Private Operator runs in an <Link href="../ref-info/glossary-uid#gl-enclave">enclave</Link>&#8212;a virtual machine with additional security features to prevent unauthorized access, so that unauthorized individuals cannot download any configuration information or data from the virtual machine.
 

--- a/docs/ref-info/glossary-uid.md
+++ b/docs/ref-info/glossary-uid.md
@@ -416,10 +416,10 @@ import Link from '@docusaurus/Link';
 
 <dt><MdxJumpAnchor id="gl-salt-bucket"><a href="#gl-salt-bucket">Salt bucket</a></MdxJumpAnchor></dt>
 <dd>A salt bucket is used to manage secret <a href="#gl-salt">salt</a> values, used to generate raw UID2s or UID2 tokens, over time. Each bucket contains a single current salt value, which remains active for approximately one year before being rotated to a new value. Buckets can be updated independently of one another.</dd>
-<dd>There are just over one million salt buckets, and each email address or phone number is assigned to a specific bucket in a deterministic manner. However, this assignment is not permanent; it might change when the bucket's current secret salt is rotated to a new value.</dd>
+<dd>There are just over one million salt buckets, and each email address or phone number is assigned to a specific bucket in a deterministic manner. However, this assignment is not permanent; it might change when the bucket's current salt is rotated to a new value.</dd>
 
 <dt><MdxJumpAnchor id="gl-salt-bucket-id"><a href="#gl-salt-bucket-id">Salt bucket ID</a></MdxJumpAnchor></dt>
-<dd>A salt bucket ID is a unique string of characters that identifies a specific <a href="#gl-salt-bucket">salt bucket</a>. The salt bucket ID can be used to check which salt buckets have recently had their secret salt values updated, indicating which emails or phone numbers need their raw UID2 values regenerated.</dd>
+<dd>A salt bucket ID is a unique string of characters that identifies a specific <a href="#gl-salt-bucket">salt bucket</a>. The salt bucket ID can be used to check which salt buckets have recently had their salt values updated, indicating which emails or phone numbers need their raw UID2 values regenerated.</dd>
 <dd>For an example of a salt bucket ID, see the response to the `POST /identity/buckets` endpoint: <a href="../endpoints/post-identity-buckets#decrypted-json-response-format">Decrypted JSON Response Format</a>.</dd>
 
 <dt><MdxJumpAnchor id="gl-salted-hash"><a href="#gl-salted-hash">Salted hash</a></MdxJumpAnchor></dt>


### PR DESCRIPTION
Minor edits to:

- CTV guide to make a bulleted list into a table.
- Glossary, modify secret salt > salt.
- UID2 Private Operator Integration Overview, minor fix.
