### PR TITLE
Add intro copy in Java SDK doc section

### DIFF
--- a/docs/sdks/sdk-ref-java.md
+++ b/docs/sdks/sdk-ref-java.md
@@ -309,6 +309,10 @@ If you're using server-side integration (see [Publisher Integration Guide, Serve
 
 ## Usage for Advertisers/Data Providers
 
+The following instructions provide an example of how to map DII to raw UID2s using the latest version of the `POST /identity/map` endpoint.
+
+For the earlier version, see [Previous SDK Version (using POST /identity/map v2)](#previous-sdk-version-using-post-identitymap-v2). For migration steps to the latest version, see [Migration From Version Using v2 Identity Map](#migration-from-version-using-v2-identity-map).
+
 1. Create an IdentityMapV3Client as an instance variable:
    ```java
    final private IdentityMapV3Client identityMapV3Client = new IdentityMapV3Client(UID2_BASE_URL, UID2_API_KEY, UID2_SECRET_KEY);


### PR DESCRIPTION
Add intro copy in Java SDK doc section, to align with corresponding Python SDK doc section.