### PR TITLE
UID2-7812, UID2-7813, UID2-7814, UID2-7815: suppress 4 CVEs in .trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -62,3 +62,32 @@ CVE-2026-73088 exp:2026-12-02
 # queries; served output is static HTML, no runtime browserslist() call.
 # See: UID2-7803
 CVE-2026-73089 exp:2026-12-02
+
+# CVE-2026-75899 — fast-uri (HIGH).
+# Not exploitable here: package-lock.json resolves fast-uri 3.1.4 only under node_modules/ajv-
+# formats/node_modules/fast-uri and node_modules/schema-utils/node_modules/fast-uri (Docusaurus
+# build tooling). fast-uri appears only in package.json overrides, lock, and .trivyignore — no
+# source import.
+# See: UID2-7812
+CVE-2026-75899 exp:2026-12-03
+
+# CVE-2026-75931 — fast-uri (HIGH).
+# Not exploitable here: fast-uri@3.1.4 appears only under node_modules/ajv-formats and
+# node_modules/schema-utils (transitive via ajv); overrides pin in package.json. Static
+# Docusaurus site; no source import of fast-uri/ajv, no fastify. Vulnerable resolve()/equal()
+# path not called by application code.
+# See: UID2-7813
+CVE-2026-75931 exp:2026-12-03
+
+# CVE-2026-75975 — fast-uri (HIGH).
+# Not exploitable here: fast-uri@3.1.4 only under ajv-formats/ajv and schema-utils/ajv in
+# lockfile; overrides ^3.1.4. Docusaurus docs site with no direct fast-uri/ajv usage in source.
+# See: UID2-7814
+CVE-2026-75975 exp:2026-12-03
+
+# CVE-2026-76172 — fast-uri (HIGH).
+# Not exploitable here: fast-uri@3.1.4 only under node_modules/ajv-formats/node_modules/ajv and
+# node_modules/schema-utils/node_modules/ajv (Docusaurus build). No direct fast-uri/ajv usage
+# in source; ajv runs at build time parsing JSON Schema URIs.
+# See: UID2-7815
+CVE-2026-76172 exp:2026-12-03


### PR DESCRIPTION
Suppresses **4 vulnerabilities** in `.trivyignore`, expiry **2026-12-03** (3 months). No code fixes — each is present in the image but not reachable from this service.

Reachability alone determines suppress-vs-fix: a fixed version existing upstream does not make an unreachable path exploitable. Change any expiry in review if you want a different window.

> **If another suppression PR is open on this repo, this one supersedes it.** Each scan run raises a fresh branch carrying every outstanding suppression, so the newest PR is a superset of the older ones — merge this and close the rest rather than merging both, which would conflict on the same append.

### CVE-2026-75899 — HIGH, `fast-uri`

The CVE is an SSRF/host-policy-bypass primitive that only manifests when an application passes an untrusted HTTP-family URI to fast-uri's normalize()/resolve() before outbound routing, redirect validation, or an allowlist check — the double percent-decode then yields a different network host. In every flagged repo, fast-uri 3.1.4 is present solely as a transitive dependency of ajv (JSON-schema validator) reached through build tooling: Docusaurus/webpack schema-utils and ajv-formats for the docs sites, CRA/webpack for the React client examples, craco/webpack for the self-serve portal, and eslint's table>ajv in the server-side example. The package.json fast-uri entries are all `overrides` security pins, not declared app dependencies, and no *.js/ts/tsx source in any repo imports fast-uri or calls normalize/resolve. ajv uses fast-uri only to resolve developer-authored, trusted schema $ref/$id URIs at build time and makes no outbound network requests based on the decoded host, so the SSRF code path is never exercised on attacker-controlled input. The vulnerable path is unreachable in all five repos.

<details>
<summary>Full triage report — CVE-2026-75899</summary>

#### CVE-2026-75899 — fast-uri SSRF via repeated hostname percent-decoding

**Severity:** HIGH (CVSS 3.1 AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N)
**Package:** fast-uri **Installed:** 3.1.4 **Fixed in:** 2.4.5, 3.1.6, 4.1.3
**Verdict:** not_affected (suppress)

##### What the CVE is
`fast-uri` decodes a hostname's percent escapes twice in a single `normalize()`/`resolve()` call — once during parsing and again during authority recomposition. A doubly percent-encoded host survives the first decode and is turned into a live destination by the second, e.g. `normalize('http://%256c%256f%2563%2561%256c%2568%256f%2573%2574/')` returns `http://localhost/`. An application that normalizes/resolves an untrusted URI *before* an SSRF check, redirect validation, or host allowlist can be steered to an internal destination (loopback, cloud metadata). This is an incomplete-fix variant of CVE-2026-6322. Workaround: reject untrusted URIs whose host contains `%25` before calling normalize/resolve.

##### How it maps to our repos
fast-uri 3.1.4 (affected) is flagged in EUID-docs, uid2-examples, uid2-self-serve-portal, uid2docs, and uid2-docs-preview. In every case it is a **transitive dependency of `ajv`** (the JSON-schema validator), reached only through build tooling:

- **EUID-docs, uid2docs, uid2-docs-preview** (Docusaurus): resolved solely under `ajv-formats/node_modules/fast-uri` and `schema-utils/node_modules/fast-uri` — webpack build-time schema validation.
- **uid2-examples** (React client examples): `node_modules/fast-uri` declared as `^3.0.1` by ajv pulled in by CRA/webpack; the server-side lock gets it via eslint's `table > ajv`.
- **uid2-self-serve-portal** (React front-end + Express backend): declared by multiple ajv instances under craco/webpack plugins.

The `fast-uri` lines in each `package.json` are `overrides` security pins (forcing the transitive version up), **not** declared application dependencies. A grep across all repos finds no `*.js/ts/tsx` source that imports fast-uri or calls `normalize()`/`resolve()`.

##### Why not affected
The vulnerable primitive requires normalizing/resolving an **untrusted** URI ahead of an outbound-routing/allowlist decision. Here fast-uri is exercised only by ajv, which resolves developer-authored, trusted schema `$ref`/`$id` URIs at build time and performs no outbound network request based on the decoded host. No production code path feeds attacker-controlled URIs into fast-uri. The SSRF/host-policy-bypass path is therefore unreachable in all five repos.

##### Decision
Not affected — reachability chain is broken (present but unreachable). Recommend suppressing this finding in each repo's root `.trivyignore`. A version bump to a patched fast-uri (via the existing overrides pin) is harmless housekeeping but is not required to remediate risk. Confidence: high.

</details>

### CVE-2026-75931 — HIGH, `fast-uri`

The CVE is a host-confusion/policy-bypass bug: an application must call fast-uri's resolve()/parse()/equal() on untrusted scheme-relative references (//host/) and then make a host-policy or routing decision on the returned host. In all five flagged repos fast-uri@3.1.4 is present only as a transitive dependency of ajv (reached through ajv-formats, schema-utils/webpack, react-scripts, and @docusaurus/*), and is additionally carried as an overrides security pin in each package.json. Grep across all non-node_modules source found zero direct imports of fast-uri or ajv, and no repo depends on fastify (count 0 everywhere) — the usual runtime consumer of fast-uri. The three docs repos are static Docusaurus sites; the portal and the uid2-examples apps are React/react-scripts (webpack) builds whose only runtime server (uid2-examples server.js) is a plain Express static file server that never touches ajv/fast-uri. ajv's sole use of fast-uri is resolving $ref URIs in trusted, developer-authored JSON schemas at build time — not resolving attacker-controlled references for host-policy decisions. The vulnerable code path is therefore not reachable in production. A fix exists (3.1.6) but availability does not change reachability, so the finding is suppressed.

<details>
<summary>Full triage report — CVE-2026-75931</summary>

### CVE-2026-75931 — fast-uri host confusion via skipped IDN canonicalization

#### Summary
- **Package:** fast-uri (JavaScript URI parser)
- **Severity:** HIGH (CVSS 3.1 AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N)
- **Installed:** 3.1.4 (vulnerable; ranges 2.4.2–2.4.4, 3.1.3–3.1.5, 4.0.1–4.1.2)
- **Fixed in:** 2.4.5, 3.1.6, 4.1.3
- **Verdict:** not_affected → suppress

#### What the CVE is
fast-uri canonicalizes a host to ASCII form only when the input carries an explicit scheme. For a scheme-relative reference (`//host/`), `resolve()` emits the host verbatim, so re-parsing the resolved URI yields a different host than `resolve()` returned. An application that resolves an untrusted reference and then checks or routes on the resulting host can make a policy decision on one host while reaching another (host confusion / policy bypass). Exploitation requires application code to feed untrusted references into fast-uri and use the extracted host for a security decision.

#### How it reaches our repos
fast-uri@3.1.4 was flagged in EUID-docs, uid2-examples, uid2-self-serve-portal, uid2docs, and uid2-docs-preview. In every case it is a **transitive dependency of `ajv`**, pulled in through `ajv-formats`, `schema-utils`/webpack, `react-scripts`, and `@docusaurus/*`. It is also carried as an `overrides` security pin in each `package.json` (forcing the ajv subtree onto a single version), which is why it also surfaces as a top-level entry.

#### Reachability analysis (code search)
- **No direct usage:** grep across all non-`node_modules` source found zero `require('fast-uri')`/`import ... 'fast-uri'` and zero direct `ajv` imports in any repo.
- **No fastify:** the usual runtime consumer of fast-uri is absent in every lock file (count 0).
- **Repo natures:** EUID-docs, uid2docs, and uid2-docs-preview are static Docusaurus sites; uid2-self-serve-portal and the uid2-examples apps are React/react-scripts (webpack) builds. The only runtime server in the examples (`server.js`) is a plain Express static file server that never touches ajv or fast-uri.
- **ajv's own use:** ajv invokes fast-uri to resolve `$ref` URIs in trusted, developer-authored JSON schemas at build/validation time — not to resolve attacker-controlled scheme-relative references for host-policy or routing decisions.

The vulnerable `resolve()`/`equal()` host-confusion path is not exercised by any application code path in these repos.

#### Decision
Reachability is not established — the package is present only in build-time schema tooling with no untrusted-input host-policy usage. Per decision logic, an unreachable path is **not_affected** regardless of an available fix. Recommend suppressing this finding (repo-root `.trivyignore`). If a future service adopts fastify or begins using fast-uri/ajv for URL/host validation on untrusted input, re-evaluate; bumping the override pin to 3.1.6 is a low-risk cleanup but is not required for security.

</details>

### CVE-2026-75975 — HIGH, `fast-uri`

The CVE is an SSRF / address-policy-bypass primitive: fast-uri's IPv6 bracket parser silently rewrites malformed literals (e.g. [::not-valid] -> [::]) to valid loopback/private addresses with no error set, so an app that normalizes an UNTRUSTED URL before an outbound request, redirect, proxy route, or host-policy check can be steered to a local/private target. Reachability therefore hinges on whether any UID2 code feeds attacker-controlled URLs through fast-uri's normalize/parse. In all five flagged repos fast-uri is present only as a transitive dependency of ajv (the JSON Schema validator), which uses fast-uri internally to resolve schema $id/$ref URIs — trusted, developer-authored schema identifiers, not network destinations. Grep across every .js/.ts/.tsx/.jsx/.mjs/.cjs source file finds zero direct imports of fast-uri and no direct ajv usage against untrusted URLs; the package is pinned solely via a package.json "overrides" entry (^3.1.4) to force-resolve the transitive copy. The consumers are Docusaurus documentation sites (EUID-docs, uid2docs, uid2-docs-preview), client-side React example apps (uid2-examples), and the self-serve portal where ajv appears under build tooling (webpack, schema-utils, eslint, workbox) plus the objection ORM's data validation. None of these normalize untrusted URLs before outbound requests, so the vulnerable IPv6-normalization path is not reachable. Verdict rests on direct evidence (lockfile parent chains, absence of source imports); the only inference is that ajv's schema-URI usage never carries attacker-controlled hosts, which is standard ajv behaviour.

<details>
<summary>Full triage report — CVE-2026-75975</summary>

#### CVE-2026-75975 — fast-uri SSRF via malformed IPv6 normalization

**Severity:** HIGH (CVSS 3.1 AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N) — GHSA-f65p-4m7j-42xc
**Package:** fast-uri, installed 3.1.4
**Fixed in:** 2.4.5, 3.1.6, 4.1.3

##### What the vulnerability is
`fast-uri` does not validate the complete RFC 3986 grammar for bracketed IPv6 literals. A malformed literal with invalid trailing text is silently truncated to a *different valid* IPv6 address, with no error reported on the parsed result. For example `normalize('http://[::not-valid]/private')` returns `http://[::]/private`, and `[fc00::not-hex]`/`[fe80::not-hex]` collapse to `[fc00::]`/`[fe80::]`. An application that normalizes an untrusted URL before an outbound request, redirect, proxy-routing decision, or host-policy/allowlist check can be redirected to loopback (`::1`), unique-local, or link-local addresses — a server-side request forgery and address-policy-bypass primitive. Because `parse().error` stays unset, consumers checking the error field cannot detect the rewrite.

##### How it appears in our repos
All five flagged repos carry `fast-uri@3.1.4` **only as a transitive dependency of `ajv`** (the JSON Schema validator), which uses fast-uri internally to parse schema `$id`/`$ref` URIs. Evidence:

- **EUID-docs / uid2docs / uid2-docs-preview** — Docusaurus documentation sites. fast-uri resolves only under `ajv-formats/node_modules/ajv` and `schema-utils/node_modules/ajv` in the lockfiles. ajv here is invoked by webpack/schema-utils at build time.
- **uid2-examples** (javascript-sdk & google-secure-signals react-client-side) — client-side React example apps; fast-uri sits solely under ajv in the lockfiles.
- **uid2-self-serve-portal** — fast-uri is pulled by many ajv copies belonging to build tooling (webpack, eslint-webpack-plugin, css/terser/mini-css plugins, workbox-build) and the `objection` ORM's data validation.

Each repo pins the version via a `package.json` `"overrides": { "fast-uri": "^3.1.4" }` entry — a resolution pin, not a direct usage. A grep across all `.js/.ts/.tsx/.jsx/.mjs/.cjs` source files found **no direct import of `fast-uri`** and no direct application code passing untrusted URLs through ajv or fast-uri.

##### Reachability decision
The exploit requires normalizing an **attacker-controlled URL** through fast-uri before an outbound request or host-policy check. Our only consumer is ajv resolving trusted, developer-authored JSON Schema identifiers — never attacker-supplied network hosts. There is no code path in any of the five repos that feeds untrusted URLs into fast-uri's `normalize`/`parse`. The vulnerable IPv6-normalization path is therefore not reachable.

**Verdict: not_affected** — suppress. Upgrading fast-uri to 3.1.6 (or bumping ajv) is harmless housekeeping and can ride along with normal dependency maintenance, but it is not security-required here since the SSRF path is unreachable. Suppression belongs in each repo's root `.trivyignore`.

</details>

### CVE-2026-76172 — HIGH, `fast-uri`

The CVE is a URI-parsing flaw in fast-uri whereby percent-encoded characters in the scheme component are decoded with legacy unescape() and re-serialized verbatim, so an input like %2f%2fevil.example:/pwn parses with no authority but resolve()/normalize() emit //evil.example:/pwn — enabling host-confusion SSRF, off-site redirects, address-policy bypass, and CRLF injection. Exploitation requires an application that normalizes or resolves untrusted, attacker-controlled URLs before a redirect check, host allowlist, or outbound request. In all five flagged repos fast-uri@3.1.4 is present strictly as a transitive dependency of ajv (JSON Schema validator); no source file imports fast-uri or ajv directly (grep across all TS/JS returned nothing). ajv invokes fast-uri only to parse the $id/$ref URIs of developer-authored JSON schemas at build/validation time — never untrusted input steered into a network or redirect decision. The docs repos (uid2docs, EUID-docs, uid2-docs-preview) are Docusaurus static-site generators where ajv is build-tooling; uid2-examples ships demo React apps whose express servers only serve the static build; the portal's ajv comes from webpack/react-scripts build tooling and the objection ORM validating fixed model schemas. The vulnerable resolve()/normalize()-on-untrusted-URL path is therefore unreachable in every repo, so the finding is not exploitable despite the package being present and a fix being available.

<details>
<summary>Full triage report — CVE-2026-76172</summary>

### CVE-2026-76172 — fast-uri host confusion via percent-encoded scheme normalization

#### Summary
`fast-uri` (a URI parser for Node.js) decodes percent-encoded characters in the URI **scheme** component using the legacy global `unescape()` and serializes the result back as raw characters without re-escaping or validating it as a scheme. An input whose scheme carries percent-encoded slashes (e.g. `%2f%2fevil.example:/pwn`, or the `%uXXXX` form) parses with **no authority** (`parse().host` is `undefined`), yet `resolve()`/`normalize()` emit `//evil.example:/pwn`, which re-parses to host `evil.example`. Control characters such as `%0d%0a` can reach the output as raw CR/LF.

- Severity: HIGH — CVSS 3.1 `AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N` (integrity impact; SSRF / off-site redirect / address-policy bypass / header CRLF injection)
- Installed: **3.1.4** (in affected range 3.0.0 → <3.1.6)
- Fixed in: 2.4.5, 3.1.6, 4.1.3

#### Attack vector (per advisory)
Exploitation requires an application that **normalizes or resolves untrusted, attacker-controlled URLs** before a redirect check, host allowlist, or outbound-request decision — especially one treating a missing authority as same-origin. The flaw lets an attacker introduce authority structure the checked input did not appear to contain.

#### Reachability analysis
`fast-uri@3.1.4` was flagged in five repos. In **every** one it is present **only transitively, as a dependency of `ajv`** (JSON Schema validator):

- **uid2docs / EUID-docs / uid2-docs-preview** — Docusaurus static-site generators. fast-uri sits under `ajv-formats/ajv` and `schema-utils/ajv`, i.e. build tooling. ajv runs at build time.
- **uid2-examples** — demo React apps (google-secure-signals, javascript-sdk react-client-side). fast-uri comes via ajv (ajv-formats, schema-utils, workbox-build). The express `server.js` only serves the static build (requires fs/path/express); no URL resolution of untrusted input.
- **uid2-self-serve-portal** — top-level `fast-uri@3.1.4` plus ~13 ajv copies from webpack, react-scripts, css/terser/mini-css plugins, eslint, babel-loader, and the `objection` ORM. ajv validates developer-defined model schemas.

A grep of all source files (`*.ts/js/tsx/jsx`, excluding node_modules) found **no direct import of `fast-uri` or `ajv`** in any repo. ajv invokes fast-uri solely to parse the `$id`/`$ref` URIs of **developer-authored JSON schemas** — not attacker-controlled URLs steered into a redirect, allowlist, or outbound-request decision. The specific vulnerable path (`resolve()`/`normalize()` over untrusted input feeding a security decision) is not exercised anywhere.

#### Decision
**not_affected.** The package is present (confirmed by the scanner and lockfiles) but the vulnerable code path is unreachable in all five repos: fast-uri is reached only through ajv's build-time / schema-validation JSON `$ref` parsing, never through application handling of untrusted URLs. Per decision logic, an available fix does not change a not-exploitable verdict.

#### Recommended action
Suppress this finding for all five repos (single repo-root `.trivyignore` per repo). A version bump to a patched fast-uri (≥3.1.6 in the 3.x line) is harmless and can be picked up naturally via ajv updates, but is not required to remediate exploitable risk here.

</details>

---
_Opened by uid2-vul-scan-agent (general_use_claude-opus-4-8) for the automated finding(s) above. Verdict confidence: high. Please sanity-check each reachability argument before approving._
